### PR TITLE
Blog display fix

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,8 @@
   ul,
   ol {
     list-style: revert;
+    margin: revert;
+    padding: revert;
   }
 }
 


### PR DESCRIPTION
Indents weren't shown when viewing a blog.
Added a new CSS rule to revert Tailwind styles and display indent.