### PR TITLE
Navbar border

### DIFF
--- a/src/components/UI/Navbar/Navbar.tsx
+++ b/src/components/UI/Navbar/Navbar.tsx
@@ -37,8 +37,8 @@ const Navbar = () => {
   }, []);
 
   return (
-    <div className="navbar-container flex flex-col justify-center items-center w-full bg-white border-slate-400 border-b-[1px] py-2 mb-0">
-      <div className="navbar flex flex-row justify-evenly items-center h-12 desktop:h-20 w-full mx-48">
+    <div className="navbar-container flex flex-col justify-center items-center m-2 mb-0 desktop:mx-48">
+      <div className="navbar flex flex-row justify-between items-center h-12 desktop:h-20 w-full mx-2">
         <LogoContainer />
         {user ? (
           <ProfileContainer user={user} />
@@ -49,6 +49,7 @@ const Navbar = () => {
         )}
       </div>
       <VerifyBanner user={user} />
+      <div className="border-slate-400 border-b-[1px] w-screen"></div>
     </div>
   );
 };


### PR DESCRIPTION
Moved the navbar border into it's own element.
The border was previously the navbar's bottom border. Classes had to be changed to allow the border to stretch across the screen.
This caused issues with the slideout menu when the user is logged in which allowed the menu to still be visible when closed.
Creating a new element for the bottom border fixes that.